### PR TITLE
refactor: type-safe options and cleanup

### DIFF
--- a/cmd/handler/option_handler.go
+++ b/cmd/handler/option_handler.go
@@ -2,43 +2,42 @@ package handler
 
 import (
 	"fmt"
-	"reflect"
 
 	flag "github.com/spf13/pflag"
 )
 
-type analysisOption struct {
+type AnalysisOptions struct {
 	Geoip  bool
 	Filter string
 }
 
-type captureOption struct {
+type CaptureOptions struct {
 	Count int
 	Time  int
 }
 
-type generalOption struct {
+type GeneralOptions struct {
 	Help    bool
 	Version bool
 }
 
-type ioOption struct {
+type IOOptions struct {
 	InterfaceName string
 	OutputFile    string
 	ReadFile      string
 }
 
-type visualizationOption struct {
-	Ascii   bool
+type VisualizationOptions struct {
 	NoAscii bool
 }
 
-type options struct {
-	Analysis      *analysisOption
-	Capture       *captureOption
-	General       *generalOption
-	Io            *ioOption
-	Visualization *visualizationOption
+// Config holds the parsed command-line options grouped by concern.
+type Config struct {
+	Analysis      AnalysisOptions
+	Capture       CaptureOptions
+	General       GeneralOptions
+	IO            IOOptions
+	Visualization VisualizationOptions
 }
 
 func HelpMessage() string {
@@ -67,57 +66,33 @@ OPTIONS:
 `
 }
 
-func buildFlagSet() (*flag.FlagSet, *options) {
-	opts := &options{
-		Capture:       &captureOption{},
-		Analysis:      &analysisOption{},
-		Visualization: &visualizationOption{},
-		General:       &generalOption{},
-		Io:            &ioOption{},
-	}
+func buildFlagSet() (*flag.FlagSet, *Config) {
+	cfg := &Config{}
 
 	flags := flag.NewFlagSet("drawlscan", flag.ContinueOnError)
 	flags.Usage = func() { fmt.Println(HelpMessage()) }
 
-	flags.BoolVarP(&opts.Analysis.Geoip, "geoip", "g", false, "Show GeoIP information for source and destination IP addresses")
-	flags.StringVarP(&opts.Analysis.Filter, "filter", "f", "", "Filter packets")
+	flags.BoolVarP(&cfg.Analysis.Geoip, "geoip", "g", false, "Show GeoIP information for source and destination IP addresses")
+	flags.StringVarP(&cfg.Analysis.Filter, "filter", "f", "", "Filter packets")
 
-	flags.IntVarP(&opts.Capture.Count, "count", "c", -1, "Capture only a specified number of packets")
-	flags.IntVarP(&opts.Capture.Time, "time", "t", -1, "Stop capturing after a specified number of seconds")
+	flags.IntVarP(&cfg.Capture.Count, "count", "c", -1, "Capture only a specified number of packets")
+	flags.IntVarP(&cfg.Capture.Time, "time", "t", -1, "Stop capturing after a specified number of seconds")
 
-	flags.BoolVarP(&opts.General.Help, "help", "h", false, "Help message")
-	flags.BoolVarP(&opts.General.Version, "version", "v", false, "Version information")
+	flags.BoolVarP(&cfg.General.Help, "help", "h", false, "Help message")
+	flags.BoolVarP(&cfg.General.Version, "version", "v", false, "Version information")
 
-	flags.StringVarP(&opts.Io.InterfaceName, "interface", "i", "", "Specify the network interface to capture packets from (e.g., eth0, wlan0)")
-	flags.StringVarP(&opts.Io.OutputFile, "output", "o", "", " Save the captured packets to a file in PCAP format")
-	flags.StringVarP(&opts.Io.ReadFile, "read", "r", "", "Read packets from a PCAP file instead of capturing live traffic")
+	flags.StringVarP(&cfg.IO.InterfaceName, "interface", "i", "", "Specify the network interface to capture packets from (e.g., eth0, wlan0)")
+	flags.StringVarP(&cfg.IO.OutputFile, "output", "o", "", " Save the captured packets to a file in PCAP format")
+	flags.StringVarP(&cfg.IO.ReadFile, "read", "r", "", "Read packets from a PCAP file instead of capturing live traffic")
 
-	flags.BoolVar(&opts.Visualization.NoAscii, "no-ascii", false, "Disable ASCII-art output")
-	return flags, opts
+	flags.BoolVar(&cfg.Visualization.NoAscii, "no-ascii", false, "Disable ASCII-art output")
+	return flags, cfg
 }
 
-func Options(optArgs []string) map[string]interface{} {
-	flags, options := buildFlagSet()
+// Options parses the given argument list (including argv[0]) and returns the
+// resulting configuration.
+func Options(optArgs []string) *Config {
+	flags, cfg := buildFlagSet()
 	flags.Parse(optArgs[1:])
-	optionMap := make(map[string]interface{})
-	collectFieldMap(reflect.ValueOf(options), optionMap)
-	return optionMap
-}
-
-func collectFieldMap(value reflect.Value, optionMap map[string]interface{}) {
-	if value.Kind() == reflect.Ptr {
-		value = value.Elem()
-	}
-	valueType := value.Type()
-
-	fields := reflect.VisibleFields(valueType)
-	for _, field := range fields {
-		fieldValue := value.FieldByIndex(field.Index)
-		key := field.Name
-		if fieldValue.Kind() == reflect.Struct || (fieldValue.Kind() == reflect.Ptr && !fieldValue.IsNil() && fieldValue.Elem().Kind() == reflect.Struct) {
-			collectFieldMap(fieldValue, optionMap)
-		} else {
-			optionMap[key] = fieldValue.Interface()
-		}
-	}
+	return cfg
 }

--- a/cmd/handler/option_handler_test.go
+++ b/cmd/handler/option_handler_test.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"reflect"
 	"testing"
 )
 
@@ -50,40 +49,19 @@ func Test_buildFlagSet(t *testing.T) {
 	}
 }
 
-func Test_collectFieldMap(t *testing.T) {
-	opts := &options{
-		Capture:       &captureOption{Count: 10, Time: 5},
-		Analysis:      &analysisOption{Geoip: true, Filter: "tcp"},
-		Visualization: &visualizationOption{Ascii: true, NoAscii: false},
-		General:       &generalOption{Help: true, Version: false},
-		Io:            &ioOption{InterfaceName: "eth0", OutputFile: "out.pcap"},
-	}
-	optionMap := make(map[string]interface{})
-	collectFieldMap(reflect.ValueOf(opts), optionMap)
-	if optionMap["Geoip"] != true {
-		t.Errorf("collectFieldMap() Geoip = %v, want true", optionMap["Geoip"])
-	}
-	if optionMap["Count"] != 10 {
-		t.Errorf("collectFieldMap() Count = %v, want 10", optionMap["Count"])
-	}
-	if optionMap["InterfaceName"] != "eth0" {
-		t.Errorf("collectFieldMap() InterfaceName = %v, want eth0", optionMap["InterfaceName"])
-	}
-}
-
 func TestOptions(t *testing.T) {
 	args := []string{"drawlscan", "--geoip", "--filter", "tcp", "--count", "5", "--interface", "eth0"}
 	got := Options(args)
-	if got["Geoip"] != true {
-		t.Errorf("Options() Geoip = %v, want true", got["Geoip"])
+	if !got.Analysis.Geoip {
+		t.Errorf("Options() Geoip = %v, want true", got.Analysis.Geoip)
 	}
-	if got["Filter"] != "tcp" {
-		t.Errorf("Options() Filter = %v, want tcp", got["Filter"])
+	if got.Analysis.Filter != "tcp" {
+		t.Errorf("Options() Filter = %v, want tcp", got.Analysis.Filter)
 	}
-	if got["Count"] != 5 {
-		t.Errorf("Options() Count = %v, want 5", got["Count"])
+	if got.Capture.Count != 5 {
+		t.Errorf("Options() Count = %v, want 5", got.Capture.Count)
 	}
-	if got["InterfaceName"] != "eth0" {
-		t.Errorf("Options() InterfaceName = %v, want eth0", got["InterfaceName"])
+	if got.IO.InterfaceName != "eth0" {
+		t.Errorf("Options() InterfaceName = %v, want eth0", got.IO.InterfaceName)
 	}
 }

--- a/cmd/layers/layer4/tcp.go
+++ b/cmd/layers/layer4/tcp.go
@@ -24,17 +24,12 @@ func tcpFlagsString(tcp *layers.TCP) string {
 	// 順序付きでフラグ名と値を並べる
 	names := []string{"FIN", "SYN", "RST", "PSH", "ACK", "URG", "ECE", "CWR", "NS"}
 	bools := []bool{tcp.FIN, tcp.SYN, tcp.RST, tcp.PSH, tcp.ACK, tcp.URG, tcp.ECE, tcp.CWR, tcp.NS}
-	// strings.FieldsFuncで一気に抽出
-	return strings.Join(
-		func() []string {
-			out := make([]string, 0, len(names))
-			for i, v := range bools {
-				if v {
-					out = append(out, names[i])
-				}
-			}
-			return out
-		}(),
-		" ",
-	)
+
+	out := make([]string, 0, len(names))
+	for i, v := range bools {
+		if v {
+			out = append(out, names[i])
+		}
+	}
+	return strings.Join(out, " ")
 }

--- a/cmd/main/drawlscan.go
+++ b/cmd/main/drawlscan.go
@@ -45,18 +45,18 @@ func processAndPrintPacket(packet gopacket.Packet, geoip bool, isAscii bool) {
 }
 
 func goMain(args []string) int {
-	optionMap := handler.Options(args)
+	cfg := handler.Options(args)
 	var (
-		count         = optionMap["Count"].(int)
-		filter        = optionMap["Filter"].(string)
-		geoip         = optionMap["Geoip"].(bool)
-		help          = optionMap["Help"].(bool)
-		iface         = optionMap["InterfaceName"].(string)
-		writeFilePath = optionMap["OutputFile"].(string)
-		readFilePath  = optionMap["ReadFile"].(string)
-		timeSec       = optionMap["Time"].(int)
-		version       = optionMap["Version"].(bool)
-		isAscii       = !optionMap["NoAscii"].(bool)
+		count         = cfg.Capture.Count
+		filter        = cfg.Analysis.Filter
+		geoip         = cfg.Analysis.Geoip
+		help          = cfg.General.Help
+		iface         = cfg.IO.InterfaceName
+		writeFilePath = cfg.IO.OutputFile
+		readFilePath  = cfg.IO.ReadFile
+		timeSec       = cfg.Capture.Time
+		version       = cfg.General.Version
+		isAscii       = !cfg.Visualization.NoAscii
 	)
 
 	if help {

--- a/cmd/main/drawlscan_test.go
+++ b/cmd/main/drawlscan_test.go
@@ -9,8 +9,25 @@ import (
 
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
+	"github.com/google/gopacket/pcap"
 	"github.com/nagayon-935/DrawlScan/cmd/utils"
 )
+
+// canCaptureLive reports whether this environment can open a live capture
+// handle (requires both a usable interface and OS-level capture permission,
+// e.g. root or CAP_NET_RAW on Linux, BPF device access on macOS).
+func canCaptureLive() bool {
+	iface := utils.AutoSelectInterface()
+	if iface == "" {
+		return false
+	}
+	handle, err := pcap.OpenLive(iface, 65535, true, pcap.BlockForever)
+	if err != nil {
+		return false
+	}
+	handle.Close()
+	return true
+}
 
 // stdOut is used for testable output redirection.
 var stdOut io.Writer = os.Stdout
@@ -69,8 +86,8 @@ func Test_processAndPrintPacket(t *testing.T) {
 }
 
 func Test_goMain_CountAndTimeOut(t *testing.T) {
-	if os.Getenv("CI") == "true" || os.Getenv("GITHUB_ACTIONS") == "true" {
-		t.Skip("Skipping this test in CI environment")
+	if !canCaptureLive() {
+		t.Skip("Skipping: no permission or interface available for live packet capture in this environment")
 	}
 	args := []string{"drawlscan", "--count", "10"}
 	if got := goMain(args); got != 0 {

--- a/cmd/utils/geoip.go
+++ b/cmd/utils/geoip.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"embed"
-	"fmt"
 	"net"
 
 	"github.com/fatih/color"
@@ -51,5 +50,5 @@ func LookupCountry(ipStr string) string {
 		"Organization: " + org,
 	}
 
-	return RenderBlock(fmt.Sprintf("GeoIP"), geoipInfo, color.New(color.FgHiRed))
+	return RenderBlock("GeoIP", geoipInfo, color.New(color.FgHiRed))
 }

--- a/cmd/utils/render_utility.go
+++ b/cmd/utils/render_utility.go
@@ -31,6 +31,8 @@ func RenderBlock(title string, lines []string, c *color.Color) string {
 	return b.String()
 }
 
+var ansiEscape = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
 func PrintHorizontalBlocks(blocks []string) {
 	if len(blocks) == 0 {
 		return
@@ -70,6 +72,5 @@ func PrintHorizontalBlocks(blocks []string) {
 }
 
 func stripANSI(input string) string {
-	var ansiEscape = regexp.MustCompile(`\x1b\[[0-9;]*m`)
 	return ansiEscape.ReplaceAllString(input, "")
 }


### PR DESCRIPTION
## Summary
- Replace the reflection-based `map[string]interface{}` option handling in `handler.Options()` with a typed `Config` struct, removing `collectFieldMap` and the interface{} type assertions at the call site
- Cache the `stripANSI` regexp at package scope instead of recompiling it on every call
- Drop a no-op `fmt.Sprintf` call and flatten an unnecessary IIFE in `tcpFlagsString`
- Fix `Test_goMain_CountAndTimeOut`, which only skipped live packet capture based on `CI`/`GITHUB_ACTIONS` env vars and therefore always failed locally without root/BPF permissions (broke `just build`/`just test`); it now probes actual capture capability and skips accordingly

## Test plan
- [x] `gofmt -l cmd/` clean
- [x] `go vet ./...` clean
- [x] `go test -race ./cmd/handler/... ./cmd/layers/... ./cmd/utils/...` all pass
- [x] `go test ./cmd/main/...` all pass (live-capture test skips cleanly without permission)
- [x] `just build` passes end to end