### PR TITLE
refactor: replace magic visibility strings with (string, bool); rune-based widths

### DIFF
--- a/cmd/handler/layer_handler.go
+++ b/cmd/handler/layer_handler.go
@@ -9,7 +9,7 @@ import (
 	"github.com/nagayon-935/DrawlScan/cmd/layers/layer7"
 )
 
-type LayerHandler func(gopacket.Packet) string
+type LayerHandler func(gopacket.Packet) (string, bool)
 
 var Handlers = []struct {
 	LayerType gopacket.LayerType

--- a/cmd/layers/layer2/arp.go
+++ b/cmd/layers/layer2/arp.go
@@ -9,12 +9,12 @@ import (
 	"github.com/nagayon-935/DrawlScan/cmd/utils"
 )
 
-func PrintARPLayer(packet gopacket.Packet) string {
+func PrintARPLayer(packet gopacket.Packet) (string, bool) {
 	arp := packet.Layer(layers.LayerTypeARP).(*layers.ARP)
 	return utils.RenderBlock("ARP Packet", []string{
 		"Sender MAC: " + net.HardwareAddr(arp.SourceHwAddress).String(),
 		"Sender IP: " + net.IP(arp.SourceProtAddress).String(),
 		"Target MAC: " + net.HardwareAddr(arp.DstHwAddress).String(),
 		"Target IP: " + net.IP(arp.DstProtAddress).String(),
-	}, color.New(color.FgHiYellow))
+	}, color.New(color.FgHiYellow)), true
 }

--- a/cmd/layers/layer2/arp_test.go
+++ b/cmd/layers/layer2/arp_test.go
@@ -44,7 +44,10 @@ func TestPrintARPLayer(t *testing.T) {
 		"Target IP: 192.168.1.1",
 	}, color.New(color.FgHiYellow))
 
-	got := PrintARPLayer(packet)
+	got, ok := PrintARPLayer(packet)
+	if !ok {
+		t.Error("PrintARPLayer() ok = false, want true")
+	}
 	if got != want {
 		t.Errorf("PrintARPLayer() = %v, want %v", got, want)
 	}

--- a/cmd/layers/layer2/ethernet.go
+++ b/cmd/layers/layer2/ethernet.go
@@ -7,11 +7,11 @@ import (
 	"github.com/nagayon-935/DrawlScan/cmd/utils"
 )
 
-func PrintEthernetLayer(packet gopacket.Packet) string {
+func PrintEthernetLayer(packet gopacket.Packet) (string, bool) {
 	eth := packet.Layer(layers.LayerTypeEthernet).(*layers.Ethernet)
 	return utils.RenderBlock("Ethernet Frame", []string{
 		"Src MAC: " + eth.SrcMAC.String(),
 		"Dst MAC: " + eth.DstMAC.String(),
 		"Type: " + eth.EthernetType.String(),
-	}, color.New(color.FgCyan))
+	}, color.New(color.FgCyan)), true
 }

--- a/cmd/layers/layer2/ethernet_test.go
+++ b/cmd/layers/layer2/ethernet_test.go
@@ -31,7 +31,10 @@ func TestPrintEthernetLayer(t *testing.T) {
 		"Type: IPv4",
 	}, color.New(color.FgCyan))
 
-	got := PrintEthernetLayer(packet)
+	got, ok := PrintEthernetLayer(packet)
+	if !ok {
+		t.Error("PrintEthernetLayer() ok = false, want true")
+	}
 	if got != want {
 		t.Errorf("PrintEthernetLayer() = %v, want %v", got, want)
 	}

--- a/cmd/layers/layer3/icmp.go
+++ b/cmd/layers/layer3/icmp.go
@@ -7,9 +7,9 @@ import (
 	"github.com/nagayon-935/DrawlScan/cmd/utils"
 )
 
-func PrintIcmpLayer(packet gopacket.Packet) string {
+func PrintIcmpLayer(packet gopacket.Packet) (string, bool) {
 	icmp := packet.Layer(layers.LayerTypeICMPv4).(*layers.ICMPv4)
 	return utils.RenderBlock("ICMP Packet", []string{
 		"Type: " + icmp.TypeCode.String(),
-	}, color.New(color.FgHiMagenta))
+	}, color.New(color.FgHiMagenta)), true
 }

--- a/cmd/layers/layer3/icmp_test.go
+++ b/cmd/layers/layer3/icmp_test.go
@@ -26,7 +26,10 @@ func TestPrintICMPLayer(t *testing.T) {
 		"Type: EchoRequest",
 	}, color.New(color.FgYellow))
 
-	got := PrintIcmpLayer(packet)
+	got, ok := PrintIcmpLayer(packet)
+	if !ok {
+		t.Error("PrintIcmpLayer() ok = false, want true")
+	}
 	if got != want {
 		t.Errorf("PrintICMPLayer() = %v, want %v", got, want)
 	}

--- a/cmd/layers/layer3/ipv4.go
+++ b/cmd/layers/layer3/ipv4.go
@@ -7,11 +7,11 @@ import (
 	"github.com/nagayon-935/DrawlScan/cmd/utils"
 )
 
-func PrintIPv4Layer(packet gopacket.Packet) string {
+func PrintIPv4Layer(packet gopacket.Packet) (string, bool) {
 	ip := packet.Layer(layers.LayerTypeIPv4).(*layers.IPv4)
 	return utils.RenderBlock("IPv4 Packet", []string{
 		"Src IP: " + ip.SrcIP.String(),
 		"Dst IP: " + ip.DstIP.String(),
 		"Protocol: " + ip.Protocol.String(),
-	}, color.New(color.FgGreen))
+	}, color.New(color.FgGreen)), true
 }

--- a/cmd/layers/layer3/ipv4_test.go
+++ b/cmd/layers/layer3/ipv4_test.go
@@ -29,7 +29,10 @@ func TestPrintIPv4Layer(t *testing.T) {
 		"Protocol: TCP",
 	}, color.New(color.FgGreen))
 
-	got := PrintIPv4Layer(packet)
+	got, ok := PrintIPv4Layer(packet)
+	if !ok {
+		t.Error("PrintIPv4Layer() ok = false, want true")
+	}
 	if got != want {
 		t.Errorf("PrintIPv4Layer() = %v, want %v", got, want)
 	}

--- a/cmd/layers/layer4/tcp.go
+++ b/cmd/layers/layer4/tcp.go
@@ -10,14 +10,14 @@ import (
 	"github.com/nagayon-935/DrawlScan/cmd/utils"
 )
 
-func PrintTcpLayer(packet gopacket.Packet) string {
+func PrintTcpLayer(packet gopacket.Packet) (string, bool) {
 	tcp := packet.Layer(layers.LayerTypeTCP).(*layers.TCP)
 
 	return utils.RenderBlock("TCP Packet", []string{
 		fmt.Sprintf("Src Port: %d", tcp.SrcPort),
 		fmt.Sprintf("Dst Port: %d", tcp.DstPort),
 		fmt.Sprintf("Flags: %s", tcpFlagsString(tcp)),
-	}, color.New(color.FgMagenta))
+	}, color.New(color.FgMagenta)), true
 }
 
 func tcpFlagsString(tcp *layers.TCP) string {

--- a/cmd/layers/layer4/tcp_test.go
+++ b/cmd/layers/layer4/tcp_test.go
@@ -51,7 +51,10 @@ func TestPrintTCPLayer(t *testing.T) {
 		"Flags: SYN ACK",
 	}, color.New(color.FgMagenta))
 
-	got := PrintTcpLayer(packet)
+	got, ok := PrintTcpLayer(packet)
+	if !ok {
+		t.Error("PrintTcpLayer() ok = false, want true")
+	}
 	if got != want {
 		t.Errorf("PrintTCPLayer() = %v, want %v", got, want)
 	}

--- a/cmd/layers/layer4/udp.go
+++ b/cmd/layers/layer4/udp.go
@@ -9,10 +9,10 @@ import (
 	"github.com/nagayon-935/DrawlScan/cmd/utils"
 )
 
-func PrintUdpLayer(packet gopacket.Packet) string {
+func PrintUdpLayer(packet gopacket.Packet) (string, bool) {
 	udp := packet.Layer(layers.LayerTypeUDP).(*layers.UDP)
 	return utils.RenderBlock("UDP Packet", []string{
 		fmt.Sprintf("Src Port: %d", udp.SrcPort),
 		fmt.Sprintf("Dst Port: %d", udp.DstPort),
-	}, color.New(color.FgBlue))
+	}, color.New(color.FgBlue)), true
 }

--- a/cmd/layers/layer4/udp_test.go
+++ b/cmd/layers/layer4/udp_test.go
@@ -47,7 +47,10 @@ func TestPrintUDPLayer(t *testing.T) {
 		"Dst Port: 53",
 	}, color.New(color.FgBlue))
 
-	got := PrintUdpLayer(packet)
+	got, ok := PrintUdpLayer(packet)
+	if !ok {
+		t.Error("PrintUdpLayer() ok = false, want true")
+	}
 	if got != want {
 		t.Errorf("PrintUDPLayer() = %v, want %v", got, want)
 	}

--- a/cmd/layers/layer7/applayer.go
+++ b/cmd/layers/layer7/applayer.go
@@ -11,17 +11,18 @@ import (
 	"github.com/nagayon-935/DrawlScan/cmd/utils"
 )
 
-func PrintAppLayer(packet gopacket.Packet) string {
+func PrintAppLayer(packet gopacket.Packet) (string, bool) {
 	protocol := DetectAppProtocol(packet)
 	switch protocol {
 	case "HTTP":
-		return printHttpInfo(packet)
+		block := printHttpInfo(packet)
+		return block, block != ""
 	case "HTTPS":
-		return utils.RenderBlock("HTTPS", []string{"Encrypted Payload"}, color.New(color.FgHiCyan))
+		return utils.RenderBlock("HTTPS", []string{"Encrypted Payload"}, color.New(color.FgHiCyan)), true
 	case "QUIC":
-		return utils.RenderBlock("QUIC", []string{"Encrypted Payload"}, color.New(color.FgHiBlack))
+		return utils.RenderBlock("QUIC", []string{"Encrypted Payload"}, color.New(color.FgHiBlack)), true
 	default:
-		return ""
+		return "", false
 	}
 }
 

--- a/cmd/layers/layer7/applayer_test.go
+++ b/cmd/layers/layer7/applayer_test.go
@@ -150,14 +150,14 @@ func TestPrintAppLayerInfo(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := PrintAppLayer(tt.packet)
+			got, ok := PrintAppLayer(tt.packet)
 			if tt.wantSub == "" {
-				if got != "" {
-					t.Errorf("PrintAppLayer(%s) = %q, want empty string", tt.name, got)
+				if ok || got != "" {
+					t.Errorf("PrintAppLayer(%s) = (%q, %v), want (\"\", false)", tt.name, got, ok)
 				}
 			} else {
-				if !strings.Contains(got, tt.wantSub) {
-					t.Errorf("PrintAppLayer(%s) = %q, want substring %q", tt.name, got, tt.wantSub)
+				if !ok || !strings.Contains(got, tt.wantSub) {
+					t.Errorf("PrintAppLayer(%s) = (%q, %v), want substring %q", tt.name, got, ok, tt.wantSub)
 				}
 			}
 		})

--- a/cmd/layers/layer7/dhcp.go
+++ b/cmd/layers/layer7/dhcp.go
@@ -11,7 +11,7 @@ import (
 	"github.com/nagayon-935/DrawlScan/cmd/utils"
 )
 
-func PrintDhcpLayer(packet gopacket.Packet) string {
+func PrintDhcpLayer(packet gopacket.Packet) (string, bool) {
 	dhcp := packet.Layer(layers.LayerTypeDHCPv4).(*layers.DHCPv4)
 	var subnetMask, router, domainName, leaseTime, serverIdentifier string
 	var domainNameServers []string
@@ -59,5 +59,5 @@ func PrintDhcpLayer(packet gopacket.Packet) string {
 		dhcpInfo = append(dhcpInfo, "Domain Name Servers: "+strings.Join(domainNameServers, ", "))
 	}
 
-	return utils.RenderBlock(fmt.Sprintf("DHCP %s", dhcp.Operation.String()), dhcpInfo, color.New(color.FgHiCyan))
+	return utils.RenderBlock(fmt.Sprintf("DHCP %s", dhcp.Operation.String()), dhcpInfo, color.New(color.FgHiCyan)), true
 }

--- a/cmd/layers/layer7/dhcp_test.go
+++ b/cmd/layers/layer7/dhcp_test.go
@@ -52,7 +52,10 @@ func TestPrintDhcpLayer_Request(t *testing.T) {
 		"Server Identifier: 192.168.1.254",
 	}, color.New(color.FgHiCyan))
 
-	got := PrintDhcpLayer(packet)
+	got, ok := PrintDhcpLayer(packet)
+	if !ok {
+		t.Error("PrintDhcpLayer() ok = false, want true")
+	}
 	if got != want {
 		t.Errorf("PrintDhcpLayer() = %v, want %v", got, want)
 	}
@@ -106,7 +109,10 @@ func TestPrintDhcpLayer_Reply(t *testing.T) {
 		"Domain Name Servers: 8.8.8.8",
 	}, color.New(color.FgHiCyan))
 
-	got := PrintDhcpLayer(packet)
+	got, ok := PrintDhcpLayer(packet)
+	if !ok {
+		t.Error("PrintDhcpLayer() ok = false, want true")
+	}
 	if got != want {
 		t.Errorf("PrintDhcpLayer() = %v, want %v", got, want)
 	}

--- a/cmd/layers/layer7/dns.go
+++ b/cmd/layers/layer7/dns.go
@@ -10,7 +10,7 @@ import (
 	"github.com/nagayon-935/DrawlScan/cmd/utils"
 )
 
-func PrintDnsLayer(packet gopacket.Packet) string {
+func PrintDnsLayer(packet gopacket.Packet) (string, bool) {
 	dns := packet.Layer(layers.LayerTypeDNS).(*layers.DNS)
 	var answerRecord []string
 
@@ -21,9 +21,9 @@ func PrintDnsLayer(packet gopacket.Packet) string {
 			}
 		}
 		if len(answerRecord) > 0 {
-			return utils.RenderBlock("DNS Packet", answerRecord, color.New(color.FgHiGreen))
+			return utils.RenderBlock("DNS Packet", answerRecord, color.New(color.FgHiGreen)), true
 		}
 	}
 
-	return "invisible"
+	return "", false
 }

--- a/cmd/layers/layer7/dns_test.go
+++ b/cmd/layers/layer7/dns_test.go
@@ -56,9 +56,9 @@ func TestPrintDnsLayer(t *testing.T) {
 
 	packet := gopacket.NewPacket(buf.Bytes(), layers.LayerTypeEthernet, gopacket.Default)
 
-	got := PrintDnsLayer(packet)
-	if got == "" {
-		t.Error("PrintDnsLayer() returned empty string, expected DNS block output")
+	got, ok := PrintDnsLayer(packet)
+	if !ok || got == "" {
+		t.Error("PrintDnsLayer() returned no content, expected DNS block output")
 	} else {
 		t.Log("DNS block:\n" + got)
 	}
@@ -84,10 +84,10 @@ func TestPrintDnsLayer(t *testing.T) {
 	}
 
 	packet = gopacket.NewPacket(buf.Bytes(), layers.LayerTypeEthernet, gopacket.Default)
-	got = PrintDnsLayer(packet)
-	if got != "invisible" {
-		t.Errorf("PrintDnsLayer() (DNS Queryのみ) = %q, want empty string", got)
+	got, ok = PrintDnsLayer(packet)
+	if ok || got != "" {
+		t.Errorf("PrintDnsLayer() (DNS Queryのみ) = (%q, %v), want (\"\", false)", got, ok)
 	} else {
-		t.Log("DNS Queryのみ: 空文字列が返ることを確認")
+		t.Log("DNS Queryのみ: 非表示(false)が返ることを確認")
 	}
 }

--- a/cmd/main/drawlscan.go
+++ b/cmd/main/drawlscan.go
@@ -18,8 +18,7 @@ func processAndPrintPacket(packet gopacket.Packet, geoip bool, isAscii bool) {
 	var blocks []string
 	for _, h := range handler.Handlers {
 		if packet.Layer(h.LayerType) != nil {
-			block := h.Handler(packet)
-			if block != "" && block != "invisible" {
+			if block, ok := h.Handler(packet); ok {
 				blocks = append(blocks, block)
 			}
 		}
@@ -27,12 +26,10 @@ func processAndPrintPacket(packet gopacket.Packet, geoip bool, isAscii bool) {
 	if geoip {
 		if netLayer := packet.NetworkLayer(); netLayer != nil {
 			src, dst := netLayer.NetworkFlow().Endpoints()
-			srcGeo := utils.LookupCountry(src.String())
-			if srcGeo != "" && srcGeo != "invisible" {
+			if srcGeo, ok := utils.LookupCountry(src.String()); ok {
 				blocks = append(blocks, srcGeo)
 			}
-			dstGeo := utils.LookupCountry(dst.String())
-			if dstGeo != "" && dstGeo != "invisible" {
+			if dstGeo, ok := utils.LookupCountry(dst.String()); ok {
 				blocks = append(blocks, dstGeo)
 			}
 		}

--- a/cmd/utils/geoip.go
+++ b/cmd/utils/geoip.go
@@ -30,8 +30,9 @@ func CloseGeoIP() {
 	}
 }
 
-// IPアドレスから国情報を取得
-func LookupCountry(ipStr string) string {
+// LookupCountry returns a rendered GeoIP block for the given IP address and
+// whether GeoIP data was found for it.
+func LookupCountry(ipStr string) (string, bool) {
 	ip := net.ParseIP(ipStr)
 
 	CountryRecord, _ := geoipCityDB.Country(ip)
@@ -41,7 +42,7 @@ func LookupCountry(ipStr string) string {
 	org := AsRecord.AutonomousSystemOrganization
 
 	if country == "" && org == "" {
-		return "invisible"
+		return "", false
 	}
 
 	geoipInfo := []string{
@@ -50,5 +51,5 @@ func LookupCountry(ipStr string) string {
 		"Organization: " + org,
 	}
 
-	return RenderBlock("GeoIP", geoipInfo, color.New(color.FgHiRed))
+	return RenderBlock("GeoIP", geoipInfo, color.New(color.FgHiRed)), true
 }

--- a/cmd/utils/geoip_test.go
+++ b/cmd/utils/geoip_test.go
@@ -27,7 +27,10 @@ func TestLookupCountry(t *testing.T) {
 	}, color.New(color.FgHiRed))
 
 	ipStr := "133.220.131.100"
-	got := LookupCountry(ipStr)
+	got, ok := LookupCountry(ipStr)
+	if !ok {
+		t.Fatal("LookupCountry() ok = false, want true")
+	}
 	if got != want {
 		t.Errorf("LookupCountry() = %v, want %v", got, want)
 	}

--- a/cmd/utils/render_utility.go
+++ b/cmd/utils/render_utility.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/fatih/color"
 )
@@ -11,10 +12,10 @@ import (
 func RenderBlock(title string, lines []string, c *color.Color) string {
 	var b strings.Builder
 
-	maxWidth := len(title)
+	maxWidth := utf8.RuneCountInString(title)
 	for _, line := range lines {
-		if len(line) > maxWidth {
-			maxWidth = len(line)
+		if w := utf8.RuneCountInString(line); w > maxWidth {
+			maxWidth = w
 		}
 	}
 	maxWidth += 2
@@ -49,7 +50,7 @@ func PrintHorizontalBlocks(blocks []string) {
 			maxLines = len(blockLines)
 		}
 		for _, line := range blockLines {
-			visibleLength := len(stripANSI(line))
+			visibleLength := utf8.RuneCountInString(stripANSI(line))
 			if visibleLength > maxWidths[i] {
 				maxWidths[i] = visibleLength
 			}
@@ -60,7 +61,7 @@ func PrintHorizontalBlocks(blocks []string) {
 		for i := 0; i < len(lines); i++ {
 			if l < len(lines[i]) {
 				fmt.Print(lines[i][l])
-				fmt.Print(strings.Repeat(" ", maxWidths[i]-len(stripANSI(lines[i][l]))))
+				fmt.Print(strings.Repeat(" ", maxWidths[i]-utf8.RuneCountInString(stripANSI(lines[i][l]))))
 			} else {
 				fmt.Print(strings.Repeat(" ", maxWidths[i]))
 			}

--- a/cmd/utils/render_utility_test.go
+++ b/cmd/utils/render_utility_test.go
@@ -1,7 +1,10 @@
 package utils
 
 import (
+	"fmt"
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/fatih/color"
 )
@@ -55,6 +58,28 @@ func TestRenderBlock(t *testing.T) {
 				t.Errorf("RenderBlock() = \n%v\nwant:\n%v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestRenderBlock_MultibyteWidth(t *testing.T) {
+	// "日本語" is 3 runes but 9 bytes in UTF-8; width must be based on
+	// visible rune count, not byte length, or the box is padded far wider
+	// than the widest visible line requires.
+	title := "日本語"
+	lines := []string{"ab"}
+
+	contentWidth := utf8.RuneCountInString(title) // widest line: 3 runes
+	maxWidth := contentWidth + 2
+
+	border := "+-" + strings.Repeat("-", maxWidth) + "-+\n"
+	want := border +
+		fmt.Sprintf("| %-*s |\n", maxWidth, title) +
+		fmt.Sprintf("| %-*s |\n", maxWidth, lines[0]) +
+		border
+
+	got := stripANSI(RenderBlock(title, lines, color.New(color.FgWhite)))
+	if got != want {
+		t.Errorf("RenderBlock() = \n%q\nwant:\n%q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
Stacked on #28 (merge that first).

- **R-2**: `handler.LayerHandler` and every `Print*Layer` function / `utils.LookupCountry` now return `(string, bool)` instead of signaling "nothing to render" via sentinel strings (`""`, `"invisible"`). Removes the magic-string comparisons from `processAndPrintPacket` in favor of a checked, typed contract.
- **R-4**: `RenderBlock` and `PrintHorizontalBlocks` now size their boxes using `utf8.RuneCountInString` instead of raw byte length, so multi-byte UTF-8 content (e.g. Japanese GeoIP/DNS text) no longer inflates the computed box width.

## Test plan
- [x] Added `TestRenderBlock_MultibyteWidth` (independently computed expected output) — confirmed it fails against the old byte-length logic and passes against the new rune-count logic
- [x] Updated all existing layer/geoip tests to the new `(string, bool)` contract
- [x] `gofmt -l cmd/` clean
- [x] `go vet ./...` clean
- [x] `go test -race ./cmd/handler/... ./cmd/layers/... ./cmd/utils/...` all pass (100% coverage maintained on layer packages)
- [x] `go test ./cmd/main/...` all pass
- [x] `just build` passes end to end